### PR TITLE
Add link to website in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,6 @@ Encoding: UTF-8
 LazyData: true
 RdMacros: Rdpack
 RoxygenNote: 7.1.2
-URL: https://github.com/SMAC-Group/ib/
+URL: https://smac-group.github.io/ib/, https://github.com/SMAC-Group/ib/
 BugReports: https://github.com/SMAC-Group/ib/issues/
 Config/testthat/edition: 3


### PR DESCRIPTION
To update gh actions, you may want to run `usethis::use_github_action("pkgdown")` and `usethis::use_github_action("check-standard")` if they fail.

You may also consider adding the website link in the About page in GitHub.
![image](https://github.com/SMAC-Group/ib/assets/52606734/b95f11d2-e5a3-4acd-b130-95a79ee15b87)
